### PR TITLE
Fix XML doc typos, stale TODOs, and exception message wording

### DIFF
--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -18,10 +18,10 @@ public class Result
     /// </summary>
     /// <param name="succeeded">A value indicating whether the operation succeeded. Set to <see langword="true"/>
     /// if the operation was successful; otherwise, <see langword="false"/>.</param>
-    /// <param name="errorMessage">Error errorMessage associated with the result.</param>
+    /// <param name="errorMessage">Error message associated with the result.</param>
     /// <remarks>
-    /// If the operation was successful, errorMessage must be an empty string. If the operation failed
-    /// errorMessage must not be null or empty
+    /// If the operation was successful, <paramref name="errorMessage"/> must be an empty string. If the operation failed,
+    /// <paramref name="errorMessage"/> must not be null or empty.
     /// </remarks>
     protected Result
     (
@@ -32,10 +32,10 @@ public class Result
         switch (succeeded)
         {
             case true when errorMessage != string.Empty:
-                throw new ArgumentException("A successful result cannot have an error errorMessage.", nameof(errorMessage));
+                throw new ArgumentException("A successful result cannot have an error message.", nameof(errorMessage));
 
             case false when string.IsNullOrWhiteSpace(errorMessage):
-                throw new ArgumentException("A failed result must have an error errorMessage.", nameof(errorMessage));
+                throw new ArgumentException("A failed result must have an error message.", nameof(errorMessage));
 
             default:
                 Succeeded = succeeded;
@@ -59,7 +59,7 @@ public class Result
 
 
     /// <summary>
-    /// Creates a successful <see cref="Result"/>>.
+    /// Creates a successful <see cref="Result"/>.
     /// </summary>
     public static Result Success() => new(true, string.Empty);
 
@@ -124,7 +124,7 @@ public class Result
     /// Returns true if any of the specified <see cref="Result"/>s indicate a failure. 
     /// Otherwise, false.
     /// </summary>
-    /// <param name="results">The array of <see cref="Result"/>> to review</param>
+    /// <param name="results">The array of <see cref="Result"/> to review.</param>
     /// <returns>
     /// <see langword="true"/> if any of the specified <see cref="Result"/>s failed, otherwise <see langword="false"/>.
     /// </returns>
@@ -137,7 +137,7 @@ public class Result
     /// <summary>
     /// Returns true if all the specified <see cref="Result"/>s indicate success. 
     /// </summary>
-    /// <param name="results">The array of <see cref="Result"/>> to review</param>
+    /// <param name="results">The array of <see cref="Result"/> to review.</param>
     /// <returns>
     /// <see langword="true"/> if all the specified <see cref="Result"/>s succeeded, otherwise <see langword="false"/>.
     /// </returns>
@@ -151,7 +151,7 @@ public class Result
 /// <summary>
 /// The result of executing an <seealso cref="Func{T}"/>. Contains properties indicating whether the operation
 /// <see cref="Result.Succeeded"/> or <see cref="Result.Failed"/>. If the operation failed the
-/// <see cref="Result.ErrorMessage"/> property will contain message as to why. If the operation succeeded the
+/// <see cref="Result.ErrorMessage"/> property will contain a message as to why. If the operation succeeded the
 /// <see cref="Result{T}.Value"/> property will contain the return value from the function.
 /// </summary>
 public class Result<T> : Result
@@ -171,11 +171,13 @@ public class Result<T> : Result
     /// </summary>
     /// <param name="succeeded">A value indicating whether the operation succeeded. Set to <see langword="true"/>
     /// if the operation was successful; otherwise, <see langword="false"/>.</param>
-    /// <param name="errorMessage">Error errorMessage associated with the result.</param>
-    /// <param name="value">The return value of the function if it succeeded, otherwise the default value for {T}</param>
+    /// <param name="errorMessage">Error message associated with the result.</param>
+    /// <param name="value">The return value of the function if it succeeded, otherwise the default value for <typeparamref name="T"/>.</param>
     /// <remarks>
-    /// If the operation was successful, errorMessage must be an empty string and value should be the return value from the function.
-    /// If the operation failed errorMessage must not be null or empty and the value should be default{T}
+    /// If the operation was successful, <paramref name="errorMessage"/> must be an empty string and
+    /// <paramref name="value"/> should be the return value from the function.
+    /// If the operation failed, <paramref name="errorMessage"/> must not be null or empty and
+    /// <paramref name="value"/> should be <c>default(T)</c>.
     /// </remarks>
 #if NET5_0_OR_GREATER
     private Result(bool succeeded, string? errorMessage, T? value) : base(succeeded, errorMessage) => _value = value;

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -21,7 +21,7 @@ public class Result
     /// <param name="errorMessage">Error message associated with the result.</param>
     /// <remarks>
     /// If the operation was successful, <paramref name="errorMessage"/> must be an empty string. If the operation failed,
-    /// <paramref name="errorMessage"/> must not be null or empty.
+    /// <paramref name="errorMessage"/> must not be null, empty, or whitespace.
     /// </remarks>
     protected Result
     (
@@ -176,7 +176,7 @@ public class Result<T> : Result
     /// <remarks>
     /// If the operation was successful, <paramref name="errorMessage"/> must be an empty string and
     /// <paramref name="value"/> should be the return value from the function.
-    /// If the operation failed, <paramref name="errorMessage"/> must not be null or empty and
+    /// If the operation failed, <paramref name="errorMessage"/> must not be null, empty, or whitespace and
     /// <paramref name="value"/> should be <c>default(T)</c>.
     /// </remarks>
 #if NET5_0_OR_GREATER

--- a/src/Wolfgang.TryPattern/Try.cs
+++ b/src/Wolfgang.TryPattern/Try.cs
@@ -16,7 +16,7 @@ public static class Try
     /// </summary>
     /// <param name="action">The action to execute.</param>
     /// <returns>
-    /// A <see cref="Result"/> that indicates if the action was successful
+    /// A <see cref="Result"/> that indicates if the action was successful.
     /// </returns>
     public static Result Run(Action action)
     {
@@ -44,7 +44,7 @@ public static class Try
     /// <param name="action">The action to execute.</param>
     /// <param name="token">The CancellationToken to monitor.</param>
     /// <returns>
-    /// A <see cref="Task"/> of <see cref="Result"/> representing the asynchronous operation
+    /// A <see cref="Task"/> of <see cref="Result"/> representing the asynchronous operation.
     /// </returns>
     public static async Task<Result> RunAsync(Action action, CancellationToken token = default)
     {
@@ -77,7 +77,7 @@ public static class Try
     /// <param name="function">The function to execute.</param>
     /// <returns>
     /// A <see cref="Result{T}"/> indicating if the function was successful or not and the result of
-    /// the function if it was. 
+    /// the function if it was.
     /// </returns>
 #if NET5_0_OR_GREATER
     public static Result<T?> Run<T>(Func<T> function)
@@ -114,6 +114,7 @@ public static class Try
         }
     }
 #endif
+
 
 
     /// <summary>
@@ -170,9 +171,4 @@ public static class Try
         }
     }
 #endif
-
-
-
-
 }
-

--- a/tests/Wolfgang.TryPattern.Tests/RunAsyncFuncTests.cs
+++ b/tests/Wolfgang.TryPattern.Tests/RunAsyncFuncTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 #endif
 namespace Wolfgang.TryPattern.Tests;
 
-public class RunAsyncFuncTests // TODO Rename class and file
+public class RunAsyncFuncTests
 {
 	[Fact]
 	public async Task RunAsync_Func_when_passed_null_throws_ArgumentNullException()

--- a/tests/Wolfgang.TryPattern.Tests/RunFuncTests.cs
+++ b/tests/Wolfgang.TryPattern.Tests/RunFuncTests.cs
@@ -3,7 +3,7 @@ using System;
 #endif
 namespace Wolfgang.TryPattern.Tests;
 
-public class RunFuncTests  // TODO Rename class and file
+public class RunFuncTests
 {
     [Fact]
     public void Run_Func_WithNullFunction_ThrowsArgumentNullException()


### PR DESCRIPTION
## Summary
- Fix "error errorMessage" typo in Result constructor docs and exception messages (3 occurrences)
- Fix extra `>` in `<see cref="Result"/>>` XML doc tags (3 occurrences)
- Use `<paramref>` and `<typeparamref>` in XML doc remarks
- Add missing periods to `<returns>` doc comments in Try.cs
- Fix spacing between methods per codebase convention (3 blank lines)
- Remove stale TODO comments from RunFuncTests and RunAsyncFuncTests

## Verification
- `dotnet build` — 0 warnings, 0 errors
- `dotnet test` — 96/96 pass
- `jb inspectcode` — 0 issues (WARNING + SUGGESTION level)
- Coverage: 100% line, 96.4% branch, 100% method

## Test plan
- [ ] CI passes (once PR #74 unblocks CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)