### PR TITLE
Revert pr.yaml trigger to pull_request (unblock CI)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,15 +4,11 @@
 # Stage 3: macOS tests (only if Stage 2 passes)
 #
 # SECURITY NOTE:
-# - Uses pull_request_target to run workflow from the trusted main branch, not from the PR branch
-# - This prevents malicious workflow YAML changes in untrusted PR branches from taking effect
-# - All checkout steps use PR refs (refs/pull/*/head) to check out PR code from the base repo
+# - Uses pull_request (not pull_request_target) to avoid the "pwn request" attack vector
+#   (pull_request_target runs from the trusted main branch with elevated permissions, and checking
+#    out untrusted PR code in that context can allow attackers to exfiltrate secrets or abuse write access)
 # - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
 #   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
-# - If a PR changes any of these protected configuration files, CI explicitly fails with instructions
-#   for a maintainer to manually review and verify the changes before merging
-# - persist-credentials: false prevents the checkout token from being written to git config for subsequent git commands
-#   (it does NOT, by itself, prevent steps from accessing github.token / GITHUB_TOKEN if you explicitly expose it)
 # - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
 
 name: PR Checks v3 (Gated)
@@ -24,7 +20,7 @@ env:
   CODECOV_MINIMUM: 90
 
 on:
-  pull_request_target:  # Runs from the main branch, not from PR branch
+  pull_request:
     branches:
       - main
 
@@ -44,8 +40,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
           fetch-depth: 0
 
       - name: Run gitleaks
@@ -70,9 +64,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
         run: |
@@ -194,9 +185,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
         run: |
@@ -496,9 +484,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
         shell: pwsh
@@ -735,9 +720,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
         run: |
@@ -1044,9 +1026,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,6 +9,8 @@
 #    out untrusted PR code in that context can allow attackers to exfiltrate secrets or abuse write access)
 # - After checkout, configuration files (.editorconfig, BannedSymbols.txt, etc.) are fetched from
 #   the main branch to prevent malicious PRs from disabling analyzers or bypassing code quality checks
+# - PRs that change protected configuration files (for example .editorconfig or Directory.Build.*)
+#   intentionally fail validation; those config changes are not evaluated by CI in the untrusted PR context
 # - Default GITHUB_TOKEN permissions are restricted to read-only repository contents to limit impact if exposed
 
 name: PR Checks v3 (Gated)


### PR DESCRIPTION
## Why

`pull_request_target` on main never fires — GitHub receives the PR events but the workflow never runs. This blocks required checks on **every** open PR, including Dependabot updates (#77, #78, #79) which can never merge.

## What

- Revert trigger: `pull_request_target` → `pull_request`
- Remove `ref: refs/pull/*/head` and `persist-credentials: false` checkout overrides (only needed for `pull_request_target`)
- Keep `fetch-depth: 0` on the gitleaks checkout
- Keep all other v3 improvements (gated stages, detect-projects, trusted config fetch, security scans)

## Merging

This PR itself is subject to the broken required checks. To merge:
1. Either temporarily disable the ruleset in settings
2. Or use admin override to bypass required checks

Once merged, all existing open PRs should have their checks start running on the next push/rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)