### PR TITLE
Fix duplicate run: key that broke pr.yaml parsing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -241,6 +241,9 @@ jobs:
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
+      # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1 from the focal-security
+      # repository so APT verifies the package via GPG instead of a plain wget download.
+      - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
           echo "deb https://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
           sudo apt-get update -q


### PR DESCRIPTION
## Root cause

The test-linux-core job in \`pr.yaml\` has an orphan \`run:\` block at line 244 — the \"Install OpenSSL 1.1 for .NET 5.0\" step lost its \`- name:\` header during a prior cleanup. YAML parsers see two \`run:\` keys under one step, which is invalid.

GitHub Actions silently fails to parse the workflow on duplicate mapping keys. That's why **no \`pull_request_target\` event has ever fired** since PR #72 merged — the workflow file was never actually loaded by GitHub Actions. Only the implicit \`push\` events registered (and failed, since there's no \`push:\` trigger defined).

## Verification

Before fix (parsing the file from main):
\`\`\`
PARSE ERROR: duplicated mapping key (244:9)
\`\`\`

After fix:
\`\`\`
PARSED OK
name: PR Checks v3 (Gated)
on keys: [ 'pull_request_target' ]
jobs: secrets-scan,detect-projects,test-linux-core,test-windows,test-macos-core,security-scan
\`\`\`

## Evidence

- Sister repo (IAsyncEnumerable-Extensions) has the same workflow and reports \`name: \"PR Checks v3 (Gated)\"\` via the API
- Try-Pattern reports \`name: \".github/workflows/pr.yaml\"\` (the file path — what GitHub uses when parsing fails)
- Run list shows only \`push\` events for the last 20 runs, zero \`pull_request_target\`

## Impact

Once merged, Dependabot PRs (#77, #78, #79) and future PRs should have their required checks run normally. This keeps the \`pull_request_target\` trust model (workflow YAML sourced from main) that was intended.

## Merging

This PR is itself subject to the broken required checks. To merge, admin override or temporarily disable the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)