### PR TITLE
Move analyzer package references from Directory.Build.props to src csproj

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,54 +6,11 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    
+
     <!-- Suppress warning about NetAnalyzers package since we're using SDK built-in -->
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
-    
+
     <!-- Treat warnings as errors in Release builds -->
     <TreatWarningsAsErrors Condition="'$(Configuration)' == 'Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Include BannedSymbols.txt as AdditionalFiles for BannedApiAnalyzers -->
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)BannedSymbols.txt" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Roslynator - Code quality and refactoring -->
-    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- AsyncFixer - Async/await best practices -->
-    <PackageReference Include="AsyncFixer" Version="2.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    
-    <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.49">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-
-    <!-- SonarAnalyzer - Industry-standard analysis -->
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.23.0.137933">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
+++ b/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
@@ -37,4 +37,47 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Include BannedSymbols.txt as AdditionalFiles for BannedApiAnalyzers -->
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\..\BannedSymbols.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Roslynator - Code quality and refactoring -->
+    <PackageReference Include="Roslynator.Analyzers" Version="4.15.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- AsyncFixer - Async/await best practices -->
+    <PackageReference Include="AsyncFixer" Version="2.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- Microsoft Threading Analyzers - Thread safety -->
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- BannedApiAnalyzers - Prevent usage of specific APIs -->
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- Meziantou - Comprehensive code quality -->
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.49">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <!-- SonarAnalyzer - Industry-standard analysis -->
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.23.0.137933">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Moves the analyzer NuGet package references and the \`BannedSymbols.txt\` \`AdditionalFiles\` entry out of \`Directory.Build.props\` and into \`src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj\`.

Packages moved:
- Roslynator.Analyzers
- AsyncFixer
- Microsoft.VisualStudio.Threading.Analyzers
- Microsoft.CodeAnalysis.BannedApiAnalyzers
- Meziantou.Analyzer
- SonarAnalyzer.CSharp

## Behavior change

Before: every project in the repo (src, tests, benchmarks, examples) inherited the analyzers.

After: only the shipped library project (\`Wolfgang.TryPattern\`) gets the analyzers. Tests, benchmarks, and examples build without analyzer warnings/errors.

\`Directory.Build.props\` still applies repo-wide for language/build settings:
- \`LangVersion\`
- \`EnableNETAnalyzers\` / \`AnalysisLevel\` / \`EnforceCodeStyleInBuild\`
- \`TreatWarningsAsErrors\` (Release only)

## Verification

- \`dotnet build --configuration Release\` → succeeds with 0 warnings, 0 errors across all TFMs
- \`dotnet test\` → 96/96 tests pass on net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)