### PR TITLE
Add .github/workflows/* to protected file detection

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -89,6 +89,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -145,11 +147,11 @@ jobs:
             fi
           done
           
-          # Check .globalconfig and .ruleset files using the same git diff approach
+          # Check .globalconfig, .ruleset, and workflow files using the same git diff approach
           # --diff-filter=AMRC: Added, Modified, Renamed, Copied (excludes Deleted)
           while IFS= read -r file; do
             changed_files+=("$file")
-          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '\.(globalconfig|ruleset)$' || true)
+          done < <(git diff --name-only --diff-filter=AMRC main-branch HEAD 2>/dev/null | grep -E '(\.(globalconfig|ruleset)|^\.github/workflows/.*\.ya?ml)$' || true)
           
           if [ ${#changed_files[@]} -gt 0 ]; then
             echo ""
@@ -213,6 +215,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -531,8 +535,8 @@ jobs:
             }
           }
           
-          # Handle glob patterns for .globalconfig and .ruleset files
-          $globPatterns = @("*.globalconfig", "*.ruleset")
+          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
+          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
           foreach ($pattern in $globPatterns) {
             $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
             foreach ($file in $files) {
@@ -757,6 +761,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists
@@ -1066,6 +1072,8 @@ jobs:
             "BannedSymbols.txt"
             "*.globalconfig"
             "*.ruleset"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
           )
           
           # Copy each configuration file from main branch if it exists


### PR DESCRIPTION
## Why

The "Detect protected configuration file changes" step in \`pr.yaml\` already fails the build (with a maintainer-review message) if a PR modifies \`.editorconfig\`, \`Directory.Build.props/.targets\`, \`BannedSymbols.txt\`, \`*.globalconfig\`, or \`*.ruleset\`. This PR extends that protection to \`.github/workflows/*.yml\`/\`*.yaml\`.

## Why it matters

\`pull_request_target\` already sources the workflow from \`main\`, so a malicious PR modifying \`pr.yaml\` on its branch can't actually take effect. But:

- A subtly broken workflow YAML (e.g. duplicate mapping key) can silently disable CI without errors. We hit this exact failure mode for ~2 weeks of merges this month before tracking it down to a duplicate \`run:\` key.
- If the trigger is ever flipped back to \`pull_request\`, workflow files would suddenly run from PR branches — and we'd get no signal that they changed.

Failing fast on workflow modifications gives maintainers a clear "review this carefully" signal regardless of the trigger model.

## Changes

- **4 bash \`Fetch trusted configuration files\` steps** (detect-projects, test-linux-core, test-macos-core, security-scan): added \`.github/workflows/*.yml\` and \`.github/workflows/*.yaml\` to \`config_files=()\`
- **1 PowerShell \`Fetch trusted configuration files\` step** (test-windows): added the same patterns to \`\$globPatterns\`
- **1 \`Detect protected configuration file changes\` step**: extended the regex to also match \`^\.github/workflows/.*\.ya?ml\$\`

## Verification

- YAML parses cleanly: \`name='PR Checks v3 (Gated)'\`, trigger=\`pull_request_target\`, 6 jobs
- Regex tested against sample file paths — matches workflow YAML/YML, still matches \`*.globalconfig\`/\`*.ruleset\`, doesn't match unrelated paths
- Net diff: +12 lines, -4 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)