### PR TITLE
Add pull_request trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,6 +3,8 @@ name: "CodeQL Security Analysis"
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   schedule:
     - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
 


### PR DESCRIPTION
## Summary
Adds the `pull_request` trigger to `.github/workflows/codeql.yaml`, matching the canonical `repo-template`.

This was missing in Try-Pattern only (audit confirmed all other repos had it). As a result, the now-required `Security Scan (CodeQL) (csharp)` status check never ran on PRs and blocked all merges (e.g. #88, #89).

## ⚠️ Self-blocking issue
Because this PR is itself a PR and the workflow file change only takes effect after merge, this PR will *also* hit the same blocking required-check problem.

To merge: temporarily remove `Security Scan (CodeQL) (csharp)` from the required checks in the `Protect main branch` ruleset, merge this PR, then re-add it. Once merged, future PRs will run CodeQL automatically and #88 / #89 will unblock.

## Test plan
- [ ] After merge, open a fresh PR and confirm `Security Scan (CodeQL) (csharp)` reports as a status check