### PR TITLE
Sync .editorconfig: relax RS0030 to none in tests and benchmarks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -376,8 +376,8 @@ dotnet_diagnostic.VSTHRD107.severity = none       # Allow Task in using without 
 dotnet_diagnostic.VSTHRD114.severity = none       # Allow returning null from Task methods in tests
 dotnet_diagnostic.VSTHRD200.severity = none       # Async suffix not required in test method names
 
-# Banned API Analyzer - Just warn in tests (allow for testing purposes)
-dotnet_diagnostic.RS0030.severity = warning       # Using banned API - warn instead of error in tests
+# Banned API Analyzer - Allow in tests (sync I/O and Stream overrides are common in test setup)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in tests
 
 # Meziantou - Relax in tests
 dotnet_diagnostic.MA0004.severity = none         # ConfigureAwait not needed in tests
@@ -422,8 +422,8 @@ dotnet_diagnostic.MA0004.severity = none          # Meziantou: Use ConfigureAwai
 dotnet_diagnostic.S3216.severity = none           # SonarAnalyzer: ConfigureAwait
 dotnet_diagnostic.CA2007.severity = none          # .NET Analyzer: Use ConfigureAwait
 
-# Banned API Analyzer - Just warn in benchmarks (allow for benchmarking purposes)
-dotnet_diagnostic.RS0030.severity = warning       # Using banned API - warn instead of error in benchmarks
+# Banned API Analyzer - Allow in benchmarks (sync APIs are often the benchmark target)
+dotnet_diagnostic.RS0030.severity = none          # Allow banned APIs in benchmarks
 
 # No documentation required for benchmarks
 dotnet_diagnostic.SA1600.severity = none


### PR DESCRIPTION
## Summary
Picks up the canonical change from [repo-template#329](https://github.com/Chris-Wolfgang/repo-template/pull/329):

- `[tests/**/*.cs]`: `dotnet_diagnostic.RS0030.severity` changed from `warning` to `none`.
- `[benchmarks/**/*.cs]`: same change.

## Why
The prior `severity = warning` was meant to "warn but allow" the banned API analyzer in test/benchmark code, but Release builds enable `TreatWarningsAsErrors` which promoted it back to error — defeating the relaxation entirely. Setting to `none` matches the existing pattern for every other relaxed rule in those folders.

Surfaced when [#94](https://github.com/Chris-Wolfgang/Try-Pattern/pull/94)'s code-fix branch began enforcing the rule on test code using `DateTime.Now` (ResultOfTTests.cs) and `Task.Wait()` (RunAsyncActionTests.cs) — both legitimate test patterns.

## Why split
`.editorconfig` is a protected file. Splitting it out of #94 keeps that PR focused on code changes and lets this canonical-sync land cleanly under its own review.

## Expected CI behavior
**`PR Checks v3 (Gated)` → `Detect protected configuration file changes` will fail by design.** The pr.yaml workflow intentionally gates `.editorconfig` changes via that step (Dependabot-exempt). This PR cannot pass automated CI as-is.

**Merge path:** maintainer manual review + admin merge (or temporary ruleset bypass), after locally verifying the diff matches canonical / repo-template#329.

## Test plan
- [x] `.editorconfig` content matches canonical's `.editorconfig` byte-for-byte (verified locally with `diff`)
- [ ] Maintainer reviews the diff against repo-template#329
- [ ] Admin merge (CI failure on protected-files guard is expected)