### PR TITLE
Suppress noisy analyzer rules in benchmarks and examples csproj

### DIFF
--- a/benchmarks/Wolfgang.TryPattern.Benchmarks/Wolfgang.TryPattern.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.TryPattern.Benchmarks/Wolfgang.TryPattern.Benchmarks.csproj
@@ -5,6 +5,18 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!--
+      Suppress analyzer rules that are noisy or non-applicable in benchmark code.
+      These are firing on the Windows CI runner despite being relaxed in
+      .editorconfig's [benchmarks/**/*.cs] section, so we suppress at the project
+      level for explicit, reliable enforcement.
+    -->
+    <NoWarn>$(NoWarn);
+      MA0004;    <!-- ConfigureAwait - benchmarks intentionally use SynchronizationContext-equivalent default -->
+      VSTHRD200; <!-- Async naming - benchmark methods don't follow 'Async' suffix convention -->
+      S6966      <!-- Sync vs async - benchmarks intentionally compare both -->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/CSharp.DotNet8.Example/CSharp.DotNet8.Example.csproj
+++ b/examples/CSharp.DotNet8.Example/CSharp.DotNet8.Example.csproj
@@ -5,6 +5,17 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!--
+      Suppress analyzer rules that are noisy or non-applicable in example code.
+      These are firing on the Windows CI runner despite being relaxed in
+      .editorconfig's [examples/**/*.cs] section, so we suppress at the project
+      level for explicit, reliable enforcement.
+    -->
+    <NoWarn>$(NoWarn);
+      MA0004;    <!-- ConfigureAwait - examples are end-user code, ConfigureAwait shouldn't be required -->
+      S6966      <!-- Sync vs async - examples can demonstrate either form -->
+    </NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

CI's Stage 2 (Windows) is reporting analyzer errors in the benchmarks and examples projects:

- `benchmarks/Wolfgang.TryPattern.Benchmarks/TryBenchmarks.cs` — VSTHRD200, MA0004
- `examples/CSharp.DotNet8.Example/Program.cs` — MA0004, S6966

These rules are already relaxed in `.editorconfig`'s `[benchmarks/**/*.cs]` and `[examples/**/*.cs]` sections, but the Windows CI runner doesn't fully honor those section relaxations (same root cause we hit on the test project). Moving the suppressions to the project level via `<NoWarn>` makes MSBuild apply them reliably.

## What

- **Benchmarks csproj:** `NoWarn` for `MA0004`, `VSTHRD200`, `S6966`
- **Examples csproj:** `NoWarn` for `MA0004`, `S6966`

Both blocks include a comment explaining why the suppressions live at the project level rather than relying on `.editorconfig`.

## Verification

- `dotnet build --configuration Release` → 0 warnings, 0 errors locally
- Should clear the remaining 28 analyzer errors on Stage 2

## Context

Split off from #94 per request — keeps that PR focused on the cancellation-token observance + test-project fixes and lets this benchmarks/examples cleanup land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)