### PR TITLE
Bump version 0.2.0 → 0.3.0

### DIFF
--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -22,7 +22,7 @@ dotnet add package Wolfgang.TryPattern
 ### PackageReference
 
 ```xml
-<PackageReference Include="Wolfgang.TryPattern" Version="0.2.0" />
+<PackageReference Include="Wolfgang.TryPattern" Version="0.3.0" />
 ```
 
 ## Basic Usage

--- a/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
+++ b/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
@@ -4,7 +4,7 @@
 	  <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	  <LangVersion>14</LangVersion>
 	  <Nullable>enable</Nullable>
-	  <Version>0.2.0</Version>
+	  <Version>0.3.0</Version>
 	  <Title>$(AssemblyName)</Title>
 	  <Authors>Chris Wolfgang</Authors>
 	  <Description>A .NET library demonstrating the Try pattern for structured error handling and result types.</Description>

--- a/tests/Wolfgang.TryPattern.Tests/Wolfgang.TryPattern.Tests.Unit.csproj
+++ b/tests/Wolfgang.TryPattern.Tests/Wolfgang.TryPattern.Tests.Unit.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net462;net472;net48;net481;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<Version>1.0.0</Version>
+		<Version>0.3.0</Version>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
Bumps `Wolfgang.TryPattern` package version 0.2.0 → 0.3.0 to release accumulated changes since the v0.2.0 tag:

- **#94** — Fix CA1000 / MA0003 / RCS1140 / RCS1163 in `Result` and `Try`. Adds `succeeded:` named arguments, fixes XML docs (RCS1140 — exception elements), removes unused parameters (RCS1163), and observes `CancellationToken` in `RunAsync<T>` overloads via `ThrowIfCancellationRequested()`.
- Centralized analyzer references in `Directory.Build.props` (Roslynator, AsyncFixer, VS.Threading, BannedApiAnalyzers, Meziantou 3.0.58, SonarAnalyzer 10.25.0.139117).
- Canonical `.editorconfig` sync (RS0030 = none in tests/benchmarks; modern C# style suggestions).
- Canonical workflow refresh (`pr.yaml`, `docfx.yaml`, `release.yaml`, `coverlet.runsettings`).

## Test plan
- [x] Local Release build clean across all TFMs
- [ ] CI green
- [ ] Tag v0.3.0 + GitHub Release after merge → release.yaml publishes to NuGet

🤖 Generated with [Claude Code](https://claude.com/claude-code)