### PR TITLE
Sync .gitignore .gitleaks.toml from canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,5 +423,11 @@ FodyWeavers.xsd
 TestResults/
 CoverageReport/
 
-# Claude Code local settings
-.claude/
+# Release workflow temporary directories
+package-smoke-test/
+nuget-packages/
+
+# DocFX generated files
+docfx_project/_site/
+docfx_project/obj/
+


### PR DESCRIPTION
## Summary
Syncs `.gitignore` and (if applicable) `.gitleaks.toml` to canonical (`repo-template/main`).

These are protected configuration files. The PR workflow will fail by design on the protected-files guard. Requires admin merge after verifying the diff matches canonical byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)