### PR TITLE
fix(docfx): restore working config; revert build-breaking review additions

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -8,12 +8,7 @@
           "src": "../"
         }
       ],
-      "dest": "api",
-      "properties": {
-        "TargetFramework": "net8.0"
-      },
-      "disableGitFeatures": false,
-      "disableDefaultFilter": false
+      "dest": "api"
     }
   ],
   "build": {
@@ -25,21 +20,15 @@
     ],
     "resource": [
       {
-        "files": ["logo.svg", "images/**"]
+        "files": ["images/**"]
       }
     ],
     "output": "_site",
-    "template": ["default", "modern"],
+    "template": ["modern", "default"],
     "globalMetadata": {
       "_appName": "Wolfgang.TryPattern",
       "_appTitle": "Wolfgang.TryPattern Documentation",
-      "_appLogoPath": "logo.svg",
       "_enableSearch": true,
-      "_appFooter": "Made with DocFX",
-      "_disableSidebar": false,
-      "_disableTocFilter": false,
-      "_enableDarkMode": true,
-      "colorMode": "dark",
       "pdf": true
     }
   }


### PR DESCRIPTION
## Summary
The current `docfx.json` produces a near-empty `_site/` — just two `index.html` files. The gh-pages site is consequently broken: site root returns 404 (no version-picker `index.html`), and `versions/v0.3.0/` was never created despite the v0.3.0 release running docfx successfully.

## Investigation findings
- Survey found Try-Pattern's `gh-pages:/docs/` empty (other repos have ~5 files there)
- Site root returns HTTP 404
- Last fully-populated version on gh-pages is `v0.2.0/` (10 files including favicon, manifest, styles/)
- Recent v0.3.0 deploy commits only modified 4 files in `versions/latest/`; never created `versions/v0.3.0/`
- Workflow log shows `docfx build` "succeeds with 0 warnings, 0 errors" but `_site/` only contains:
  ```
  _site/index.html        (5786 bytes)
  _site/api/index.html    (4308 bytes)
  ```
- Compared to IComparable-Extensions's working `docfx.json`: nearly identical structure except for the additions in commit `cdfe7fc`

## Root cause
Commit `cdfe7fc Address Copilot review` added several "improvements" that broke docfx's template-asset generation:

| Change | Status |
|---|---|
| Added `properties.TargetFramework: net8.0` in metadata | Reverted |
| Added explicit `logo.svg` to resources + `_appLogoPath` reference | Reverted |
| Reversed template order: `["modern", "default"]` → `["default", "modern"]` | Reverted |
| Expanded globalMetadata with `_appFooter`, `_disableSidebar`, `_disableTocFilter`, `_enableDarkMode`, `colorMode` | Reverted |
| Added `disableGitFeatures: false` and `disableDefaultFilter: false` (explicit defaults) | Reverted |
| Removed `src/<path>/<project>.csproj` placeholder, used `src/**/*.csproj` glob | **Kept** (legitimate fix) |

The cosmetic `_appName: "Wolfgang.TryPattern"` and `_appTitle` strings are kept since they're display-only.

The reverted state matches the working pattern used by IComparable-Extensions (https://chris-wolfgang.github.io/IComparable-Extensions/ renders correctly).

## Validation plan after merge
1. Manually trigger `docfx.yaml` via workflow_dispatch
2. Verify `_site/` after build contains a full set of files (favicon, manifest, styles/, search assets, per-page HTML, etc.) — not just two index.html files
3. Verify `https://chris-wolfgang.github.io/Try-Pattern/` returns the version-picker page (HTTP 200)
4. Verify `versions/v0.3.0/` now exists and contains the published v0.3.0 docs

## Follow-ups (separate)
- Clean up the `v0.1.0-3` git tag and "Release attempt 3" GitHub release (legacy retry artifact)
- Clean up the orphan `v.0.1.0-v2` Draft release (`v0.1.0-2` tag)