### PR TITLE
Bump version 0.3.0 → 0.3.1

### DIFF
--- a/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
+++ b/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
@@ -4,7 +4,7 @@
 	  <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	  <LangVersion>14</LangVersion>
 	  <Nullable>enable</Nullable>
-	  <Version>0.3.0</Version>
+	  <Version>0.3.1</Version>
 	  <Title>$(AssemblyName)</Title>
 	  <Authors>Chris Wolfgang</Authors>
 	  <Description>A .NET library demonstrating the Try pattern for structured error handling and result types.</Description>


### PR DESCRIPTION
## Summary
Infrastructure-only release. No `src/` changes since v0.3.0 — the purpose of v0.3.1 is to verify the `release.yaml` → `docfx.yaml` chain deploys docs end-to-end after the recent fixes.

## Background
- **PR #108** untracked the poison-pill `docfx_project/_site/.gitignore` (`* !.gitignore`) that was being copied into the gh-pages worktree on every deploy and blocking `git add -A` from picking up new content. Verified the fix works via `workflow_dispatch`.
- **PR #110** (open) is the comprehensive sync from canonical — includes the newer `docfx.yaml` resilience fixes (try/finally extraheader cleanup, explicit exit on deploy failure, ls-remote failure detection). Either order is fine — this version-bump can land before or after #110.

## Test plan after merge
1. Create a v0.3.1 release in the GitHub UI (Try-Pattern uses `release.published` trigger)
2. `release.yaml` fires:
   - validate / pack / smoke / nuget-publish all succeed
   - `docfx.yaml` (called as reusable workflow) builds + deploys to gh-pages
3. Verify on gh-pages:
   - `versions/v0.3.1/` populated
   - `versions/latest/` updated to v0.3.1
   - `versions.json` lists `latest, v0.3.1, v0.3.0, v0.2.0, v0.1.0`
4. Verify on the live site: https://chris-wolfgang.github.io/Try-Pattern/ shows `v0.3.1` in the version picker
5. Verify NuGet publish: `Wolfgang.TryPattern@0.3.1` appears on nuget.org

## Note
Doesn't touch any protected files — should sail through CI without override.