### PR TITLE
chore: sync .gitignore + .gitattributes from canonical

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,12 +15,13 @@
 # on checkout). BOM-free UTF-8 encoding is enforced separately by
 # .editorconfig's global `charset = utf-8` — `.gitattributes` can
 # normalize line endings (and control text/binary, diff, and merge
-# behavior) but has no attribute for byte-order marks. LF is required
-# for the
-# `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
-# parses CR as part of the interpreter name (looking for `pwsh\r`),
-# and a UTF-8 BOM before `#!` would prevent shebang recognition
-# entirely. Modern PowerShell 7+ handles LF on Windows transparently.
+# behavior) but has no attribute for byte-order marks.
+#
+# LF is required for the `#!/usr/bin/env pwsh` shebang to work on
+# Linux/macOS — the kernel parses CR as part of the interpreter name
+# (looking for `pwsh\r`), and a UTF-8 BOM before `#!` would prevent
+# shebang recognition entirely. Modern PowerShell 7+ handles LF on
+# Windows transparently.
 *.ps1 text eol=lf
 
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,10 @@
 # the working tree (the explicit `eol=lf` overrides any user-level
 # `core.autocrlf=true` setting that would otherwise convert to CRLF
 # on checkout). BOM-free UTF-8 encoding is enforced separately by
-# .editorconfig's global `charset = utf-8` — .gitattributes can only
-# control EOL, not byte-order marks. LF is required for the
+# .editorconfig's global `charset = utf-8` — `.gitattributes` can
+# normalize line endings (and control text/binary, diff, and merge
+# behavior) but has no attribute for byte-order marks. LF is required
+# for the
 # `#!/usr/bin/env pwsh` shebang to work on Linux/macOS — the kernel
 # parses CR as part of the interpreter name (looking for `pwsh\r`),
 # and a UTF-8 BOM before `#!` would prevent shebang recognition

--- a/.gitignore
+++ b/.gitignore
@@ -427,7 +427,13 @@ CoverageReport/
 package-smoke-test/
 nuget-packages/
 
-# DocFX generated files
-docfx_project/_site/
+# DocFX generated files (any depth)
+_site/
 docfx_project/obj/
+# Auto-generated API metadata: `docfx metadata` writes <Type>.yml and toc.yml
+# under docfx_project/api/ for every public type extracted from src/. Keep
+# these out of the repo so a careless `git add -A` after running docfx
+# metadata locally doesn't commit generated files. The hand-written
+# index.md and README.md in api/ are intentionally tracked.
+docfx_project/api/*.yml
 


### PR DESCRIPTION
## Summary
Two small drifts that landed on canonical after PR #110 was opened:

### `.gitignore`
- Picks up the new `docfx_project/api/*.yml` rule from canonical [#355](https://github.com/Chris-Wolfgang/repo-template/pull/355) — defensive against accidentally tracking docfx metadata output (the same family of bug that was the root cause of PR #108's poison-pill `_site/.gitignore`).
- Broadens the existing `_site/` rule to match any depth, matching canonical (was: more-specific `docfx_project/_site/`).

### `.gitattributes`
- Picks up the slightly more elaborate `*.ps1` comment from canonical (clarifies `.gitattributes` can normalize line endings + control text/binary/diff/merge behavior, but has no attribute for byte-order marks — that's `.editorconfig`'s job).

## Note about the protected-files guard
This PR touches `.gitignore` and `.gitattributes` (both protected). The `Detect .NET Projects` guard will block — maintainer override required.

## Verification
After merge, Try-Pattern will be byte-identical to canonical for both files.