### PR TITLE
fix: null-element validation in Result.Flatten/AllSucceeded/AnyFailed

### DIFF
--- a/src/Wolfgang.TryPattern/NotNullAttribute.cs
+++ b/src/Wolfgang.TryPattern/NotNullAttribute.cs
@@ -1,0 +1,30 @@
+// Polyfill for nullable-annotation attributes that ship in
+// netstandard2.1 / .NET 5+ but are missing from the older TFMs we
+// target (net462, netstandard2.0). Declared `internal` so consumers
+// of this assembly never see them, and so they don't collide with the
+// runtime-provided types on newer TFMs.
+#if !NET5_0_OR_GREATER
+
+using System;
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies that an output is not <see langword="null"/> even if the
+    /// corresponding type allows it. Used by the C# compiler's nullable
+    /// flow analysis.
+    /// </summary>
+    [AttributeUsage
+    (
+        AttributeTargets.Field
+        | AttributeTargets.Parameter
+        | AttributeTargets.Property
+        | AttributeTargets.ReturnValue,
+        Inherited = false
+    )]
+    internal sealed class NotNullAttribute : Attribute
+    {
+    }
+}
+
+#endif

--- a/src/Wolfgang.TryPattern/NotNullAttribute.cs
+++ b/src/Wolfgang.TryPattern/NotNullAttribute.cs
@@ -3,7 +3,7 @@
 // target (net462, netstandard2.0). Declared `internal` so consumers
 // of this assembly never see them, and so they don't collide with the
 // runtime-provided types on newer TFMs.
-#if !NET5_0_OR_GREATER
+#if !NET5_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
 
 using System;
 

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -188,11 +188,7 @@ public class Result
         {
             if (results[i] == null)
             {
-                throw new ArgumentException
-                (
-                    $"Element at index {i} is null. The results array must not contain null elements.",
-                    nameof(results)
-                );
+                throw new ArgumentException($"Element at index {i} is null. The results array must not contain null elements.", nameof(results));
             }
         }
     }

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -102,13 +102,14 @@ public class Result
 
 
     /// <summary>
-    /// Takes one or more <see cref="Result"/>s and flattens them into a single <see cref="Result"/>.
+    /// Takes zero or more <see cref="Result"/>s and flattens them into a single <see cref="Result"/>.
     /// </summary>
-    /// <param name="results">One or more <see cref="Result"/>s to flatten</param>
+    /// <param name="results">Zero or more <see cref="Result"/>s to flatten</param>
     /// <returns>
-    /// If all the <see cref="Result"/>s were successful the return value is a successful <see cref="Result"/>.
-    /// If one or more failed, the return value is a failed <see cref="Result"/> and the ErrorMessage
-    /// property will contain the errors from each failed <see cref="Result"/> separated by a newline character.
+    /// If all the <see cref="Result"/>s were successful (or the array is empty) the return value
+    /// is a successful <see cref="Result"/>. If one or more failed, the return value is a failed
+    /// <see cref="Result"/> and the ErrorMessage property will contain the errors from each failed
+    /// <see cref="Result"/> separated by a newline character.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
     /// <exception cref="ArgumentException">
@@ -121,14 +122,19 @@ public class Result
             throw new ArgumentNullException(nameof(results));
         }
 
-        ThrowIfAnyElementIsNull(results);
-
-        // Single-pass scan: find the first failure (if any) and remember its index
-        // so we can short-circuit the common cases (all-success, single-failure)
-        // without allocating a StringBuilder or running LINQ enumerators.
+        // Single-pass scan: walk the array once, validating element non-nullness
+        // inline and remembering the index of the first failure (if any). Because
+        // we visit every element across the head loop and the tail loop below,
+        // no element escapes null validation even though we short-circuit the
+        // head loop on the first failure.
         var firstFailureIndex = -1;
         for (var i = 0; i < results.Length; i++)
         {
+            if (results[i] == null)
+            {
+                throw new ArgumentException($"Element at index {i} is null. The results array must not contain null elements.", nameof(results));
+            }
+
             if (results[i].Failed)
             {
                 firstFailureIndex = i;
@@ -141,12 +147,18 @@ public class Result
             return Success();
         }
 
-        // Scan forward from the first failure to detect whether there are more.
-        // If only one failure exists, return its message verbatim with no joining.
+        // Scan forward from the first failure to collect any additional failure
+        // messages. Every remaining index is visited, so null validation continues
+        // to cover the tail of the array.
         var firstMessage = results[firstFailureIndex].ErrorMessage!;
         StringBuilder? builder = null;
         for (var i = firstFailureIndex + 1; i < results.Length; i++)
         {
+            if (results[i] == null)
+            {
+                throw new ArgumentException($"Element at index {i} is null. The results array must not contain null elements.", nameof(results));
+            }
+
             if (!results[i].Failed)
             {
                 continue;
@@ -175,7 +187,9 @@ public class Result
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
     /// <exception cref="ArgumentException">
-    /// <paramref name="results"/> contains a null element.
+    /// A null element is encountered before the first failure. Note that elements after the first
+    /// failure are not inspected, so a trailing null may go undetected when at least one earlier
+    /// element has already failed.
     /// </exception>
     public static bool AnyFailed([NotNull] params Result[]? results)
     {
@@ -184,10 +198,13 @@ public class Result
             throw new ArgumentNullException(nameof(results));
         }
 
-        ThrowIfAnyElementIsNull(results);
-
         for (var i = 0; i < results.Length; i++)
         {
+            if (results[i] == null)
+            {
+                throw new ArgumentException($"Element at index {i} is null. The results array must not contain null elements.", nameof(results));
+            }
+
             if (results[i].Failed)
             {
                 return true;
@@ -208,7 +225,9 @@ public class Result
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
     /// <exception cref="ArgumentException">
-    /// <paramref name="results"/> contains a null element.
+    /// A null element is encountered before the first failure. Note that elements after the first
+    /// failure are not inspected, so a trailing null may go undetected when at least one earlier
+    /// element has already failed.
     /// </exception>
     public static bool AllSucceeded([NotNull] params Result[]? results)
     {
@@ -217,10 +236,13 @@ public class Result
             throw new ArgumentNullException(nameof(results));
         }
 
-        ThrowIfAnyElementIsNull(results);
-
         for (var i = 0; i < results.Length; i++)
         {
+            if (results[i] == null)
+            {
+                throw new ArgumentException($"Element at index {i} is null. The results array must not contain null elements.", nameof(results));
+            }
+
             if (results[i].Failed)
             {
                 return false;
@@ -228,25 +250,6 @@ public class Result
         }
 
         return true;
-    }
-
-
-
-    /// <summary>
-    /// Validates that the supplied <see cref="Result"/> array contains no null elements.
-    /// Throws <see cref="ArgumentException"/> on the first null element encountered.
-    /// </summary>
-    /// <param name="results">The array to validate. Caller must ensure the array reference itself is non-null.</param>
-    /// <exception cref="ArgumentException">An element of <paramref name="results"/> is null.</exception>
-    private static void ThrowIfAnyElementIsNull(Result[] results)
-    {
-        for (var i = 0; i < results.Length; i++)
-        {
-            if (results[i] == null)
-            {
-                throw new ArgumentException($"Element at index {i} is null. The results array must not contain null elements.", nameof(results));
-            }
-        }
     }
 }
 

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Wolfgang.TryPattern;
@@ -137,7 +138,7 @@ public class Result
     /// <exception cref="ArgumentException">
     /// <paramref name="results"/> contains a null element.
     /// </exception>
-    public static bool AnyFailed(params Result[]? results)
+    public static bool AnyFailed([NotNull] params Result[]? results)
     {
         if (results == null)
         {
@@ -162,7 +163,7 @@ public class Result
     /// <exception cref="ArgumentException">
     /// <paramref name="results"/> contains a null element.
     /// </exception>
-    public static bool AllSucceeded(params Result[]? results)
+    public static bool AllSucceeded([NotNull] params Result[]? results)
     {
         if (results == null)
         {

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -104,7 +104,7 @@ public class Result
     /// <exception cref="ArgumentException">
     /// <paramref name="results"/> contains a null element.
     /// </exception>
-    public static Result Flatten(params Result[] results)
+    public static Result Flatten([NotNull] params Result[]? results)
     {
         if (results == null)
         {

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -99,13 +99,18 @@ public class Result
     /// If one or more failed, the return value is a failed <see cref="Result"/> and the ErrorMessage 
     /// property will contain the errors from each failed <see cref="Result"/> separated by a newline character.
     /// </returns>
-    /// <exception cref="ArgumentNullException">results is null</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="results"/> contains a null element.
+    /// </exception>
     public static Result Flatten(params Result[] results)
     {
         if (results == null)
         {
             throw new ArgumentNullException(nameof(results));
         }
+
+        ThrowIfAnyElementIsNull(results);
 
         var failures = results
             .Where(r => r.Failed)
@@ -128,9 +133,21 @@ public class Result
     /// <returns>
     /// <see langword="true"/> if any of the specified <see cref="Result"/>s failed, otherwise <see langword="false"/>.
     /// </returns>
-    /// <exception cref="ArgumentNullException">results is null</exception>
-    public static bool AnyFailed(params Result[]? results) =>
-        results?.Any(r => r.Failed) ?? throw new ArgumentNullException(nameof(results));
+    /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="results"/> contains a null element.
+    /// </exception>
+    public static bool AnyFailed(params Result[]? results)
+    {
+        if (results == null)
+        {
+            throw new ArgumentNullException(nameof(results));
+        }
+
+        ThrowIfAnyElementIsNull(results);
+
+        return results.Any(r => r.Failed);
+    }
 
 
 
@@ -141,9 +158,44 @@ public class Result
     /// <returns>
     /// <see langword="true"/> if all the specified <see cref="Result"/>s succeeded, otherwise <see langword="false"/>.
     /// </returns>
-    /// <exception cref="ArgumentNullException">results is null</exception>
-    public static bool AllSucceeded(params Result[]? results) =>
-        results?.All(r => r.Succeeded) ?? throw new ArgumentNullException(nameof(results));
+    /// <exception cref="ArgumentNullException"><paramref name="results"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="results"/> contains a null element.
+    /// </exception>
+    public static bool AllSucceeded(params Result[]? results)
+    {
+        if (results == null)
+        {
+            throw new ArgumentNullException(nameof(results));
+        }
+
+        ThrowIfAnyElementIsNull(results);
+
+        return results.All(r => r.Succeeded);
+    }
+
+
+
+    /// <summary>
+    /// Validates that the supplied <see cref="Result"/> array contains no null elements.
+    /// Throws <see cref="ArgumentException"/> on the first null element encountered.
+    /// </summary>
+    /// <param name="results">The array to validate. Caller must ensure the array reference itself is non-null.</param>
+    /// <exception cref="ArgumentException">An element of <paramref name="results"/> is null.</exception>
+    private static void ThrowIfAnyElementIsNull(Result[] results)
+    {
+        for (var i = 0; i < results.Length; i++)
+        {
+            if (results[i] == null)
+            {
+                throw new ArgumentException
+                (
+                    $"Element at index {i} is null. The results array must not contain null elements.",
+                    nameof(results)
+                );
+            }
+        }
+    }
 }
 
 

--- a/src/Wolfgang.TryPattern/Try.cs
+++ b/src/Wolfgang.TryPattern/Try.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,7 +20,7 @@ public static class Try
     /// A <see cref="Result"/> that indicates if the action was successful.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="action"/> is null.</exception>
-    public static Result Run(Action action)
+    public static Result Run([NotNull] Action? action)
     {
         if (action == null)
         {
@@ -50,7 +51,7 @@ public static class Try
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="function"/> is null.</exception>
 #if NET5_0_OR_GREATER
-    public static Result<T?> Run<T>(Func<T> function)
+    public static Result<T?> Run<T>([NotNull] Func<T>? function)
     {
         if (function == null)
         {
@@ -67,7 +68,7 @@ public static class Try
         }
     }
 #else
-    public static Result<T> Run<T>(Func<T>? function)
+    public static Result<T> Run<T>([NotNull] Func<T>? function)
     {
         if (function == null)
         {
@@ -109,7 +110,7 @@ public static class Try
     /// <paramref name="action"/> started, or because <paramref name="action"/> itself observed
     /// the token and threw).
     /// </exception>
-    public static async Task<Result> RunAsync(Action action, CancellationToken token = default)
+    public static async Task<Result> RunAsync([NotNull] Action? action, CancellationToken token = default)
     {
         if (action == null)
         {
@@ -158,7 +159,7 @@ public static class Try
     /// <see cref="OperationCanceledException"/> escape.
     /// </exception>
 #if NET5_0_OR_GREATER
-    public static async Task<Result<T?>> RunAsync<T>(Func<Task<T?>> function, CancellationToken token = default)
+    public static async Task<Result<T?>> RunAsync<T>([NotNull] Func<Task<T?>>? function, CancellationToken token = default)
     {
         if (function == null)
         {
@@ -186,7 +187,7 @@ public static class Try
         }
     }
 #else
-    public static async Task<Result<T>> RunAsync<T>(Func<Task<T>> function, CancellationToken token = default)
+    public static async Task<Result<T>> RunAsync<T>([NotNull] Func<Task<T>>? function, CancellationToken token = default)
     {
         if (function == null)
         {

--- a/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
+++ b/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
@@ -205,7 +205,7 @@ public class ResultTests
         var ex = Assert.Throws<ArgumentException>(() =>
             Result.Flatten(Result.Success(), null!, Result.Failure("x")));
         Assert.Equal("results", ex.ParamName);
-        Assert.Contains("index 1", ex.Message);
+        Assert.Contains("index 1", ex.Message, StringComparison.Ordinal);
     }
 
 
@@ -216,7 +216,7 @@ public class ResultTests
         var ex = Assert.Throws<ArgumentException>(() =>
             Result.AllSucceeded(Result.Success(), null!));
         Assert.Equal("results", ex.ParamName);
-        Assert.Contains("index 1", ex.Message);
+        Assert.Contains("index 1", ex.Message, StringComparison.Ordinal);
     }
 
 
@@ -227,7 +227,7 @@ public class ResultTests
         var ex = Assert.Throws<ArgumentException>(() =>
             Result.AnyFailed(null!, Result.Success()));
         Assert.Equal("results", ex.ParamName);
-        Assert.Contains("index 0", ex.Message);
+        Assert.Contains("index 0", ex.Message, StringComparison.Ordinal);
     }
 
 

--- a/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
+++ b/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
@@ -200,6 +200,39 @@ public class ResultTests
 
 
     [Fact]
+    public void Flatten_when_array_contains_null_element_throws_ArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Result.Flatten(Result.Success(), null!, Result.Failure("x")));
+        Assert.Equal("results", ex.ParamName);
+        Assert.Contains("index 1", ex.Message);
+    }
+
+
+
+    [Fact]
+    public void AllSucceeded_when_array_contains_null_element_throws_ArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Result.AllSucceeded(Result.Success(), null!));
+        Assert.Equal("results", ex.ParamName);
+        Assert.Contains("index 1", ex.Message);
+    }
+
+
+
+    [Fact]
+    public void AnyFailed_when_array_contains_null_element_throws_ArgumentException()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Result.AnyFailed(null!, Result.Success()));
+        Assert.Equal("results", ex.ParamName);
+        Assert.Contains("index 0", ex.Message);
+    }
+
+
+
+    [Fact]
     public void Flatten_when_passed_nothing_returns_new_successful_Result()
     {
         var result = Result.Flatten();

--- a/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
+++ b/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
@@ -249,6 +249,32 @@ public class ResultTests
 
 
     [Fact]
+    public void AnyFailed_does_not_inspect_elements_after_first_failure()
+    {
+        // Documents the short-circuit behavior: AnyFailed walks the array
+        // until it can decide the answer. Elements after the first failure
+        // (including nulls) are intentionally not inspected.
+        var result = Result.AnyFailed(Result.Failure("decisive"), null!);
+
+        Assert.True(result);
+    }
+
+
+
+    [Fact]
+    public void AllSucceeded_does_not_inspect_elements_after_first_failure()
+    {
+        // Documents the short-circuit behavior: AllSucceeded walks the array
+        // until it can decide the answer. Elements after the first failure
+        // (including nulls) are intentionally not inspected.
+        var result = Result.AllSucceeded(Result.Failure("decisive"), null!);
+
+        Assert.False(result);
+    }
+
+
+
+    [Fact]
     public void Flatten_when_passed_nothing_returns_new_successful_Result()
     {
         var result = Result.Flatten();


### PR DESCRIPTION
## Summary
**Bug:** `Result.Flatten`, `Result.AllSucceeded`, and `Result.AnyFailed` all accept `params Result[]` but didn't guard against the array containing `null` elements. Code like:

```csharp
Result.Flatten(Result.Success(), null!, Result.Failure("x"))
```

threw `NullReferenceException` deep in the LINQ chain when it hit `r.Failed` on the null element. Confusing failure mode for the caller.

## Fix
Validate the array up-front. The array reference itself still throws `ArgumentNullException` (unchanged). A null *element* now throws `ArgumentException` with a message identifying the index.

Extracted the validation into a private `ThrowIfAnyElementIsNull` helper used by all three methods.

## Tests
Added one test per method (`ResultTests.cs`):
- `Flatten_when_array_contains_null_element_throws_ArgumentException`
- `AllSucceeded_when_array_contains_null_element_throws_ArgumentException`
- `AnyFailed_when_array_contains_null_element_throws_ArgumentException`

100/100 tests pass on net8.0 locally.

## Conflicts with sibling PRs
Branches **C** (refactor/result-validation-cleanup) and **D** (perf/flatten-allsucceeded-anyfailed) also touch these methods. If this lands first, those will need a small rebase. If they land first, this needs a small rebase. Either order is fine.