### PR TITLE
perf: cache Result.Success() singleton

### DIFF
--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -58,10 +58,18 @@ public class Result
 
 
 
+    private static readonly Result SuccessInstance = new(succeeded: true, string.Empty);
+
+
+
     /// <summary>
     /// Creates a successful <see cref="Result"/>.
     /// </summary>
-    public static Result Success() => new(succeeded: true, string.Empty);
+    /// <remarks>
+    /// Returns a cached singleton instance. <see cref="Result"/> is immutable, so reusing
+    /// the same instance is safe and avoids per-call allocations on hot paths.
+    /// </remarks>
+    public static Result Success() => SuccessInstance;
 
 
 

--- a/src/Wolfgang.TryPattern/Result.cs
+++ b/src/Wolfgang.TryPattern/Result.cs
@@ -58,7 +58,7 @@ public class Result
 
 
 
-    private static readonly Result SuccessInstance = new(succeeded: true, string.Empty);
+    private static readonly Result _successInstance = new(succeeded: true, string.Empty);
 
 
 
@@ -67,9 +67,11 @@ public class Result
     /// </summary>
     /// <remarks>
     /// Returns a cached singleton instance. <see cref="Result"/> is immutable, so reusing
-    /// the same instance is safe and avoids per-call allocations on hot paths.
+    /// the same instance is safe and avoids per-call allocations on hot paths. Callers must
+    /// not rely on reference identity to distinguish results: every call to <see cref="Success"/>
+    /// returns the same object, so two successful results will be reference-equal.
     /// </remarks>
-    public static Result Success() => SuccessInstance;
+    public static Result Success() => _successInstance;
 
 
 

--- a/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
+++ b/tests/Wolfgang.TryPattern.Tests/ResultTests.cs
@@ -62,6 +62,22 @@ public class ResultTests
 
 
     [Fact]
+    public void Success_returns_the_same_cached_instance_on_every_call()
+    {
+        // Locks in the singleton optimization: Result is immutable, so
+        // Success() intentionally returns a shared instance to avoid
+        // per-call allocations. If this assertion ever needs to be
+        // relaxed, it is a deliberate behavioral change that consumers
+        // relying on reference identity should be notified about.
+        var first = Result.Success();
+        var second = Result.Success();
+
+        Assert.Same(first, second);
+    }
+
+
+
+    [Fact]
     public void Failure_sets_properties_correctly()
     {
         const string message = "Test Error";


### PR DESCRIPTION
## Summary
- `Result` is immutable, so `Success()` can return a single shared instance instead of allocating on every call.
- Eliminates per-call allocations on hot paths (`Flatten`, `Try.Run`, consumer code).

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release --framework net8.0` — 97 passed
- [ ] CI green across all TFMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)