### PR TITLE
Bump version 0.3.1 → 0.3.2

### DIFF
--- a/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
+++ b/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
@@ -4,7 +4,7 @@
 	  <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	  <LangVersion>14</LangVersion>
 	  <Nullable>enable</Nullable>
-	  <Version>0.3.1</Version>
+	  <Version>0.3.2</Version>
 	  <Title>$(AssemblyName)</Title>
 	  <Authors>Chris Wolfgang</Authors>
 	  <Description>A .NET library demonstrating the Try pattern for structured error handling and result types.</Description>


### PR DESCRIPTION
## Summary
Version bump for the v0.3.2 release. PATCH bump per Conventional Commits — one `fix`, two `perf`, one `refactor`, two `chore` since v0.3.1. No breaking changes.

## ⚠️ Prerequisite: merge #118 first
This branch only bumps the csproj version. The Meziantou.Analyzer bump (#118) is a **separate PR** that must land on `main` *before* the `v0.3.2` tag is pushed, otherwise the analyzer bump won't make it into the release.

**Required merge order:**
1. Merge #118 (Meziantou.Analyzer 3.0.77 → 3.0.85)
2. Merge this PR (#119, version bump)
3. Push `v0.3.2` tag to trigger `release.yaml` (NuGet publish + GitHub Release + docfx deploy)

## Already-merged PRs included in v0.3.2 (since v0.3.1)
- #113 fix: null-element validation in `Result.Flatten` / `AllSucceeded` / `AnyFailed` (+ `[NotNull]` on all entry points, `NotNullAttribute` polyfill for net462/netstandard2.0)
- #114 perf: cache `Result.Success()` singleton
- #115 refactor: simplify `Result` ctor validation (switch → guard-clause ifs)
- #116 perf: replace LINQ in `Flatten` / `AllSucceeded` / `AnyFailed` with for-loops
- #117 chore: test cleanup

## Pending PRs to merge before tagging
- #118 chore(deps): Bump Meziantou.Analyzer 3.0.77 → 3.0.85

## Behavior changes worth noting in release notes
- `Result.Success()` now returns a shared singleton. Callers must not rely on reference identity to distinguish results — documented in the XML `<remarks>` and locked in by a test.
- `Result.AllSucceeded` / `AnyFailed` now short-circuit on first failure and **do not validate elements past the decisive index** (previous up-front pre-scan always validated every element). A trailing null element after the deciding failure is no longer caught. Documented in `<exception>` XML and locked in by two new tests.
- New runtime guard: passing a null element to any of `Flatten` / `AllSucceeded` / `AnyFailed` now throws `ArgumentException` with the index, instead of `NullReferenceException`.

## Test plan
- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [x] `dotnet test -c Release` across all 10 TFMs (net462–net10.0) — 88/88 each
- [ ] CI green on this PR
- [ ] After #118 + #119 merged: push `v0.3.2` tag to trigger release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)