### PR TITLE
fix: restore <AssemblyVersion>1.0.0.0</AssemblyVersion> (C4 post-mortem)

### DIFF
--- a/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
+++ b/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
@@ -5,6 +5,13 @@
 	  <LangVersion>14</LangVersion>
 	  <Nullable>enable</Nullable>
 	  <Version>0.3.2</Version>
+	  <!-- Pin AssemblyVersion to MAJOR.0.0.0 so .NET Framework consumers
+	       do not need a binding redirect on every minor/patch bump. Only
+	       change this on a deliberate breaking API change. FileVersion +
+	       InformationalVersion (auto-derived from <Version>) carry the
+	       actual release version. -->
+	  <AssemblyVersion>1.0.0.0</AssemblyVersion>
+	  <FileVersion>$(Version).0</FileVersion>
 	  <Title>$(AssemblyName)</Title>
 	  <Authors>Chris Wolfgang</Authors>
 	  <Description>A .NET library demonstrating the Try pattern for structured error handling and result types.</Description>

--- a/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
+++ b/src/Wolfgang.TryPattern/Wolfgang.TryPattern.csproj
@@ -5,13 +5,13 @@
 	  <LangVersion>14</LangVersion>
 	  <Nullable>enable</Nullable>
 	  <Version>0.3.2</Version>
-	  <!-- Pin AssemblyVersion to MAJOR.0.0.0 so .NET Framework consumers
-	       do not need a binding redirect on every minor/patch bump. Only
-	       change this on a deliberate breaking API change. FileVersion +
-	       InformationalVersion (auto-derived from <Version>) carry the
-	       actual release version. -->
+	  <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+	       do not need to recompile / add binding redirects on every minor/patch
+	       bump. Bump only on a deliberate breaking API change. FileVersion +
+	       InformationalVersion (the latter auto-derived from <Version>) carry
+	       the actual release version. -->
 	  <AssemblyVersion>1.0.0.0</AssemblyVersion>
-	  <FileVersion>$(Version).0</FileVersion>
+	  <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 	  <Title>$(AssemblyName)</Title>
 	  <Authors>Chris Wolfgang</Authors>
 	  <Description>A .NET library demonstrating the Try pattern for structured error handling and result types.</Description>


### PR DESCRIPTION
Restores `<AssemblyVersion>1.0.0.0</AssemblyVersion>` + adds `<FileVersion>$(Version).0</FileVersion>` to the src csproj.

## Why

The original C4 fanout dropped `<AssemblyVersion>` on the rationale that the hardcoded `1.0.0` was "stale" relative to released package versions. But that staleness was the **correct** binding-stability behaviour for a library that ships a `net462` TFM. With SDK-derived AssemblyVersion, every minor/patch release ships a different binding identity, so .NET Framework consumers need a binding redirect on every bump or they hit a runtime `FileLoadException`.

DateTime-Extensions v1.3.0 publicly shipped this regression. **This repo has not yet released the regression** (the C4 drop is on `canonical-unprotected` but hasn't reached `main`). Landing this fix neutralises the footgun before any merge to main.

## Standard library pattern (NodaTime / Newtonsoft / AutoMapper)

| Property | Bumps on | Example |
|---|---|---|
| `AssemblyVersion` | **MAJOR only** | `1.0.0.0` |
| `AssemblyFileVersion` | every release | `<Version>.0` |
| `Version` (NuGet) | every release | `<Version>` |

`AssemblyVersion` only changes on a deliberate breaking API change (i.e., `2.0.0.0`).

Tracked in the per-repo-release-pilot skill as the corrected Phase 2 step 1.