### PR TITLE
dependabot.yml: drop the retired 'dotnet' label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/src"
@@ -16,7 +15,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/tests"
@@ -25,7 +23,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/benchmarks"
@@ -34,7 +31,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"
 
   - package-ecosystem: "nuget"
     directory: "/examples"
@@ -43,4 +39,3 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "dotnet"


### PR DESCRIPTION
Dependabot is failing every PR creation with:

> `The following labels could not be found: dotnet. Please create it before Dependabot can add it to a pull request.`

The `dotnet` label was retired fleet-wide as part of the canonical cleanup (repo-template#365). This PR removes the remaining references from `.github/dependabot.yml` so Dependabot can keep opening PRs.

Touches only `.github/dependabot.yml` — not a protected path, no admin-bypass needed.

Fleet-wide fix; companion PRs land in every other affected repo.